### PR TITLE
use UnsupportedOperationException instead of UnsupportedMediaException

### DIFF
--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.lib.envinject;
 
-import com.sun.xml.internal.ws.server.UnsupportedMediaException;
 import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import org.apache.commons.collections.map.UnmodifiableMap;
@@ -100,6 +99,6 @@ public class EnvInjectAction implements Action, StaplerProxy {
 
 
     public Object getTarget() {
-        throw new UnsupportedMediaException();
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
UnsupportedMediaException means "can't  understand request message's Content-Type". 
UnsupportedOperationException is better to me.
