### PR TITLE
[JENKINS-36184]  Doing reflection with hudson.matrix.MatrixRun

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <jenkins.core.version>1.565.1</jenkins.core.version>
+        <jenkins.core.version>1.532</jenkins.core.version>
     </properties>
 
     <scm>
@@ -54,11 +54,6 @@
             <artifactId>jenkins-core</artifactId>
             <version>${jenkins.core.version}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.4</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
-        <jenkins.core.version>1.532</jenkins.core.version>
+        <jenkins.core.version>1.565.1</jenkins.core.version>
     </properties>
 
     <scm>
@@ -54,6 +54,11 @@
             <artifactId>jenkins-core</artifactId>
             <version>${jenkins.core.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.4</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
@@ -30,7 +30,7 @@ public class EnvInjectActionRetriever {
         } catch (ClassNotFoundException e) {
             actions = build.getActions();
         }
-        
+
         for (Action action : actions) {
             if (action == null) {
                 continue;

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
@@ -19,12 +19,12 @@ public class EnvInjectActionRetriever {
     //with EnvInjectAction subclasses. Subclasses cannot be casted from
     //all point of Jenkins (classes are not loaded in some points)
     public Action getEnvInjectAction(AbstractBuild<?, ?> build) {
-        List<Action> actions;
         if (build == null) {
             throw new NullPointerException("A build object must be set.");
         }
         try {
             Class<?> matrixClass = Class.forName("hudson.matrix.MatrixRun");
+            List<Action> actions;
             if (matrixClass.isInstance(build)) {
                 Method method = matrixClass.getMethod("getParentBuild", null);
                 Object object = method.invoke(build);
@@ -32,26 +32,24 @@ public class EnvInjectActionRetriever {
                     build = (AbstractBuild<?, ?>) object;
                 }
             }
+            actions = build.getActions();
+            for (Action action : actions) {
+                if (action == null) {
+                    continue;
+                }
+
+                if (EnvInjectAction.URL_NAME.equals(action.getUrlName())) {
+                    return action;
+                }
+            }
         } catch (ClassNotFoundException e) {
-            LOGGER.log(Level.FINEST, String.format("hudson.matrix.MatrixRun is missed", e));
+            LOGGER.log(Level.FINEST, String.format("hudson.matrix.MatrixRun is not installed", e));
         } catch (NoSuchMethodException e) {
             LOGGER.log(Level.WARNING, String.format("The method getParentBuild does not exist for hudson.matrix.MatrixRun", e));
         } catch (IllegalAccessException e) {
             LOGGER.log(Level.WARNING, String.format("There was a problem in the invocation of getParentBuild in hudson.matrix.MatrixRun", e));
         } catch (InvocationTargetException e) {
             LOGGER.log(Level.WARNING, String.format("There was a problem in the invocation of getParentBuild in hudson.matrix.MatrixRun", e));
-        } finally {
-            actions = build.getActions();
-        }
-
-        for (Action action : actions) {
-            if (action == null) {
-                continue;
-            }
-
-            if (EnvInjectAction.URL_NAME.equals(action.getUrlName())) {
-                return action;
-            }
         }
         return null;
     }

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
@@ -16,18 +16,21 @@ public class EnvInjectActionRetriever {
     //with EnvInjectAction subclasses. Subclasses cannot be casted from
     //all point of Jenkins (classes are not loaded in some points)
     public Action getEnvInjectAction(AbstractBuild<?, ?> build) {
-
+        List<Action> actions;
         if (build == null) {
             throw new NullPointerException("A build object must be set.");
         }
-
-        List<Action> actions;
-        if (build instanceof MatrixRun) {
-            actions = ((MatrixRun) build).getParentBuild().getActions();
-        } else {
+        try {
+            Class.forName("hudson.matrix.MatrixRun");
+            if (build instanceof MatrixRun) {
+                actions = ((MatrixRun) build).getParentBuild().getActions();
+            } else {
+                actions = build.getActions();
+            }
+        } catch (ClassNotFoundException e) {
             actions = build.getActions();
         }
-
+        
         for (Action action : actions) {
             if (action == null) {
                 continue;

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
@@ -19,27 +19,17 @@ public class EnvInjectActionRetriever {
     //with EnvInjectAction subclasses. Subclasses cannot be casted from
     //all point of Jenkins (classes are not loaded in some points)
     public Action getEnvInjectAction(AbstractBuild<?, ?> build) {
+        List<Action> actions;
         if (build == null) {
             throw new NullPointerException("A build object must be set.");
         }
         try {
             Class<?> matrixClass = Class.forName("hudson.matrix.MatrixRun");
-            List<Action> actions;
             if (matrixClass.isInstance(build)) {
                 Method method = matrixClass.getMethod("getParentBuild", null);
                 Object object = method.invoke(build);
                 if (object instanceof AbstractBuild<?, ?>) {
                     build = (AbstractBuild<?, ?>) object;
-                }
-            }
-            actions = build.getActions();
-            for (Action action : actions) {
-                if (action == null) {
-                    continue;
-                }
-
-                if (EnvInjectAction.URL_NAME.equals(action.getUrlName())) {
-                    return action;
                 }
             }
         } catch (ClassNotFoundException e) {
@@ -50,6 +40,16 @@ public class EnvInjectActionRetriever {
             LOGGER.log(Level.WARNING, String.format("There was a problem in the invocation of getParentBuild in hudson.matrix.MatrixRun", e));
         } catch (InvocationTargetException e) {
             LOGGER.log(Level.WARNING, String.format("There was a problem in the invocation of getParentBuild in hudson.matrix.MatrixRun", e));
+        }
+        actions = build.getActions();
+        for (Action action : actions) {
+            if (action == null) {
+                continue;
+            }
+
+            if (EnvInjectAction.URL_NAME.equals(action.getUrlName())) {
+                return action;
+            }
         }
         return null;
     }


### PR DESCRIPTION
This is to avoid issues like [JENKINS-36184](https://issues.jenkins-ci.org/browse/JENKINS-36184) 

```
jun 23, 2016 1:24:01 PM hudson.model.Executor finish1
SEVERE: Executor threw an exception
java.lang.NoClassDefFoundError: hudson/matrix/MatrixRun
    at org.jenkinsci.lib.envinject.service.EnvInjectActionRetriever.getEnvInjectAction(EnvInjectActionRetriever.java:25)
    at org.jenkinsci.lib.envinject.service.EnvVarsResolver.getEnVars(EnvVarsResolver.java:56)
    at hudson.plugins.batch_task.BatchRun.run(BatchRun.java:224)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:410)
Caused by: java.lang.ClassNotFoundException: hudson.matrix.MatrixRun
    at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1376)
    at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1326)
    at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1079)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    ... 5 more
```

@reviewbybees CC @oleg-nenashev