### PR TITLE
[JENKINS-43535] - Minimize usage of AbstractProject/AbstractBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+Changelog
+===
+
+### 1.25
+
+Release date: Coming soon
+
+* [JENKINS-43845](https://issues.jenkins-ci.org/browse/JENKINS-43845) -
+Deprecate obsolete utility methods in the library.
+Methods have been moved to the [EnvInject API Plugin](https://plugins.jenkins.io/envinject-api).
+* [JENKINS-43535](https://issues.jenkins-ci.org/browse/JENKINS-43535) - 
+Make `EnvInjectAction` API compatible with non-`AbstractProject` job types like Jenkins Pipeline
+
+#### Developer notes
+
+* Starting from this version, the library should not be directly used by plugins
+  * Use dependency on the [EnvInject API Plugin](https://plugins.jenkins.io/envinject-api) instead.
+  * Remove explicit dependency on the EnvInject Library.
+  * Replace all usages of the 
+`org.jenkinsci.lib.envinject.service` package by the new methods offered by the plugin. 
+
+# 1.24
+
+Release date: _Jul 01, 2016_
+
+* [JENKINS-36184](https://issues.jenkins-ci.org/browse/JENKINS-36184) - 
+Remove implicit dependency on the [Matrix Project Plugin](https://plugins.jenkins.io/matrix-project), 
+which has been detached from the core.
+It was causing regressions in Jenkins installations without this plugin.
+ 
+### Changes before 1.24
+
+See the commit history

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2012-2017 Gregory Boissinot, Oleg Nenashev, and other Jenkins contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+Jenkins EnvInject Library
+===
+
+Provides basic API for declaring and retrieving environment variables in Jenkins builds.
+
+## Usage
+
+Starting from `1.25` this library is provided via in the [EnvInject API Plugin](https://plugins.jenkins.io/envinject-api) and should not be used as a direct dependency in Jenkins plugins.
+The library guarantees backward compatibility of API and does not contribute any user-visible components by default.
+
+You can see usage examples in the [EnvInject Plugin](https://plugins.jenkins.io/envinject).
+
+## Documentation
+
+* [Changelog](CHANGELOG.md)
+* [EnvInject API Plugin Documentation](https://github.com/jenkinsci/envinject-api-plugin/) - migrated API documentation
+
+## License
+
+[MIT License](https://opensource.org/licenses/mit-license.php)

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -1,9 +1,7 @@
 package org.jenkinsci.lib.envinject;
 
 import com.google.common.collect.Maps;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
+import hudson.model.Job;
 import hudson.model.Run;
 import org.apache.commons.collections.map.UnmodifiableMap;
 import org.jenkinsci.lib.envinject.service.EnvInjectSavable;
@@ -16,19 +14,29 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.model.RunAction2;
 
-//TODO: Convert to RunAction2
 /**
  * @author Gregory Boissinot
  */
-public class EnvInjectAction implements Action, StaplerProxy {
+public class EnvInjectAction implements RunAction2, StaplerProxy {
 
     public static final String URL_NAME = "injectedEnvVars";
 
     protected transient @CheckForNull Map<String, String> envMap;
  
-    private @Nonnull AbstractBuild build;
+    private transient @Nonnull Run<?, ?> build;
 
+    @Override
+    public void onAttached(Run<?, ?> run) {
+        build = run;
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> run) {
+        build = run;
+    }
+ 
     /**
      * Backward compatibility
      */
@@ -36,7 +44,7 @@ public class EnvInjectAction implements Action, StaplerProxy {
     private transient File rootDir;
     private transient @CheckForNull Set<String> sensibleVariables;
 
-    public EnvInjectAction(@Nonnull AbstractBuild build, 
+    public EnvInjectAction(@Nonnull Run<?,?> build, 
             @CheckForNull Map<String, String> envMap) {
         this.build = build;
         this.envMap = envMap;
@@ -114,13 +122,13 @@ public class EnvInjectAction implements Action, StaplerProxy {
     }
 
 
-    private Map<String, String> getEnvironment(@CheckForNull AbstractBuild build) throws EnvInjectException {
+    private Map<String, String> getEnvironment(@CheckForNull Run<?, ?> build) throws EnvInjectException {
 
         if (build == null) {
             return null;
         }
 
-        AbstractProject project = build.getProject();
+        Job<?, ?> project = build.getParent();
         if (project == null) {
             return null;
         }

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.lib.envinject;
 
 import com.google.common.collect.Maps;
+import hudson.model.AbstractBuild;
 import hudson.model.Job;
 import hudson.model.Run;
 import org.apache.commons.collections.map.UnmodifiableMap;
@@ -44,9 +45,26 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
     private transient File rootDir;
     private transient @CheckForNull Set<String> sensibleVariables;
 
-    public EnvInjectAction(@Nonnull Run<?,?> build, 
+    /**
+     * Constructs action for the specified environment variables.
+     * @param build Build
+     * @param envMap Environment Map 
+     * @deprecated The action implements {@link RunAction2} now, hence passing build is not required anymore.
+     *             Use {@link #EnvInjectAction(java.util.Map)}.
+     */
+    @Deprecated
+    public EnvInjectAction(@Nonnull AbstractBuild build, 
             @CheckForNull Map<String, String> envMap) {
         this.build = build;
+        this.envMap = envMap;
+    }
+    
+    /**
+     * Constructs action for the specified environment variables.
+     * @param envMap Environment Map 
+     * @since 0.25
+     */
+    public EnvInjectAction(@CheckForNull Map<String, String> envMap) {
         this.envMap = envMap;
     }
 

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectLogger.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectLogger.java
@@ -3,10 +3,15 @@ package org.jenkinsci.lib.envinject;
 import hudson.model.TaskListener;
 
 import java.io.Serializable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
+ * @deprecated The actual version of this API class is located in EnvInject API Plugin
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
 public class EnvInjectLogger implements Serializable {
 
     private TaskListener listener;

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectLogger.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectLogger.java
@@ -3,15 +3,10 @@ package org.jenkinsci.lib.envinject;
 import hudson.model.TaskListener;
 
 import java.io.Serializable;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
- * @deprecated The actual version of this API class is located in EnvInject API Plugin
  */
-@Deprecated
-@Restricted(NoExternalUse.class)
 public class EnvInjectLogger implements Serializable {
 
     private TaskListener listener;

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.lib.envinject.service;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Action;
+import hudson.model.Run;
 import org.jenkinsci.lib.envinject.EnvInjectAction;
 
 import java.lang.reflect.InvocationTargetException;
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
 
 /**
  * @author Gregory Boissinot
@@ -18,18 +19,18 @@ public class EnvInjectActionRetriever {
     //Returns the abstract class Action due to a class loading issue
     //with EnvInjectAction subclasses. Subclasses cannot be casted from
     //all point of Jenkins (classes are not loaded in some points)
-    public Action getEnvInjectAction(AbstractBuild<?, ?> build) {
+    public Action getEnvInjectAction(@Nonnull Run<?, ?> build) {
         List<Action> actions;
         if (build == null) {
-            throw new NullPointerException("A build object must be set.");
+            throw new NullPointerException("A Run object must be set.");
         }
         try {
             Class<?> matrixClass = Class.forName("hudson.matrix.MatrixRun");
             if (matrixClass.isInstance(build)) {
                 Method method = matrixClass.getMethod("getParentBuild", null);
                 Object object = method.invoke(build);
-                if (object instanceof AbstractBuild<?, ?>) {
-                    build = (AbstractBuild<?, ?>) object;
+                if (object instanceof Run<?, ?>) {
+                    build = (Run<?, ?>) object;
                 }
             }
         } catch (ClassNotFoundException e) {

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
@@ -9,10 +9,15 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
+ * @deprecated The actual version of this API class is located in EnvInject API Plugin
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
 public class EnvInjectActionRetriever {
 
     //Returns the abstract class Action due to a class loading issue

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectActionRetriever.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.lib.envinject.service;
 
+import hudson.model.AbstractBuild;
 import hudson.model.Action;
-import hudson.model.Run;
 import org.jenkinsci.lib.envinject.EnvInjectAction;
 
 import java.lang.reflect.InvocationTargetException;
@@ -9,7 +9,6 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 
 /**
  * @author Gregory Boissinot
@@ -19,18 +18,18 @@ public class EnvInjectActionRetriever {
     //Returns the abstract class Action due to a class loading issue
     //with EnvInjectAction subclasses. Subclasses cannot be casted from
     //all point of Jenkins (classes are not loaded in some points)
-    public Action getEnvInjectAction(@Nonnull Run<?, ?> build) {
+    public Action getEnvInjectAction(AbstractBuild<?, ?> build) {
         List<Action> actions;
         if (build == null) {
-            throw new NullPointerException("A Run object must be set.");
+            throw new NullPointerException("A build object must be set.");
         }
         try {
             Class<?> matrixClass = Class.forName("hudson.matrix.MatrixRun");
             if (matrixClass.isInstance(build)) {
                 Method method = matrixClass.getMethod("getParentBuild", null);
                 Object object = method.invoke(build);
-                if (object instanceof Run<?, ?>) {
-                    build = (Run<?, ?>) object;
+                if (object instanceof AbstractBuild<?, ?>) {
+                    build = (AbstractBuild<?, ?>) object;
                 }
             }
         } catch (ClassNotFoundException e) {

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
@@ -9,6 +9,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
+ * @deprecated The actual version of this API class is located in EnvInject API Plugin
  */
 @Deprecated
 @Restricted(NoExternalUse.class)

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
@@ -1,16 +1,16 @@
 package org.jenkinsci.lib.envinject.service;
 
 import hudson.Plugin;
+import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import hudson.model.Hudson;
-import hudson.model.Run;
 
 /**
  * @author Gregory Boissinot
  */
 public class EnvInjectDetector {
 
-    public boolean isEnvInjectActivated(Run<?, ?> build) {
+    public boolean isEnvInjectActivated(AbstractBuild build) {
 
         if (build == null) {
             throw new NullPointerException("A build object must be set.");

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
@@ -1,16 +1,16 @@
 package org.jenkinsci.lib.envinject.service;
 
 import hudson.Plugin;
-import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import hudson.model.Hudson;
+import hudson.model.Run;
 
 /**
  * @author Gregory Boissinot
  */
 public class EnvInjectDetector {
 
-    public boolean isEnvInjectActivated(AbstractBuild build) {
+    public boolean isEnvInjectActivated(Run<?, ?> build) {
 
         if (build == null) {
             throw new NullPointerException("A build object must be set.");

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectDetector.java
@@ -4,10 +4,14 @@ import hudson.Plugin;
 import hudson.model.AbstractBuild;
 import hudson.model.Action;
 import hudson.model.Hudson;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
 public class EnvInjectDetector {
 
     public boolean isEnvInjectActivated(AbstractBuild build) {

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectSavable.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectSavable.java
@@ -7,10 +7,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
+ * @deprecated The actual version of this API class is located in EnvInject API Plugin
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
 public class EnvInjectSavable {
 
     private static final String ENVINJECT_TXT_FILENAME = "injectedEnvVars.txt";

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvVarsResolver.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvVarsResolver.java
@@ -16,10 +16,15 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
+ * @deprecated The actual version of this API class is located in EnvInject API Plugin
  */
+@Deprecated
+@Restricted(NoExternalUse.class)
 public class EnvVarsResolver implements Serializable {
 
     public Map<String, String> getPollingEnvVars(AbstractProject project, /*can be null*/ Node node) throws EnvInjectException {

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvVarsResolver.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvVarsResolver.java
@@ -22,38 +22,38 @@ import java.util.Map;
  */
 public class EnvVarsResolver implements Serializable {
 
-    public Map<String, String> getPollingEnvVars(AbstractProject project, /*can be null*/ Node node) throws EnvInjectException {
+    public Map<String, String> getPollingEnvVars(Job<?, ?> job, /*can be null*/ Node node) throws EnvInjectException {
 
-        if (project == null) {
+        if (job == null) {
             throw new NullPointerException("A project object must be set.");
         }
 
-        Run lastBuild = project.getLastBuild();
+        Run lastBuild = job.getLastBuild();
         if (lastBuild != null) {
             EnvInjectDetector detector = new EnvInjectDetector();
             if (detector.isEnvInjectPluginInstalled()) {
-                return getEnVars((AbstractBuild) lastBuild);
+                return getEnVars(lastBuild);
             }
         }
 
         if (node == null) {
-            return getFallBackMasterNode(project);
+            return getFallBackMasterNode(job);
         }
         if (node.getRootPath() == null) {
-            return getFallBackMasterNode(project);
+            return getFallBackMasterNode(job);
         }
 
-        return getDefaultEnvVarsJob(project, node);
+        return getDefaultEnvVarsJob(job, node);
     }
 
-    public Map<String, String> getEnVars(AbstractBuild build) throws EnvInjectException {
+    public Map<String, String> getEnVars(Run<?, ?> run) throws EnvInjectException {
 
-        if (build == null) {
+        if (run == null) {
             throw new NullPointerException("A build object must be set.");
         }
 
         EnvInjectActionRetriever envInjectActionRetriever = new EnvInjectActionRetriever();
-        Action envInjectAction = envInjectActionRetriever.getEnvInjectAction(build);
+        Action envInjectAction = envInjectActionRetriever.getEnvInjectAction(run);
         if (envInjectAction != null) {
             try {
                 Method method = envInjectAction.getClass().getMethod("getEnvMap");
@@ -67,26 +67,27 @@ public class EnvVarsResolver implements Serializable {
             }
         }
 
-        Node builtOn = build.getBuiltOn();
-        //-- Check if node is always on. Otherwise, gather master env vars
+        // Retrieve node used for this build
+        Node builtOn = (run instanceof AbstractBuild) ? ((AbstractBuild)run).getBuiltOn() : null;
+        
+        // Check if node is always on. Otherwise, gather master env vars
         if (builtOn == null) {
-            return getFallBackMasterNode(build.getProject());
+            return getFallBackMasterNode(run.getParent());
         }
         if (builtOn.getRootPath() == null) {
-            return getFallBackMasterNode(build.getProject());
+            return getFallBackMasterNode(run.getParent());
         }
-        //-- End check
 
-        //Get envVars from the node of the last build
-        return getDefaultEnvVarsJob(build.getProject(), builtOn);
+        // Get envVars from the node of the last build
+        return getDefaultEnvVarsJob(run.getParent(), builtOn);
     }
 
-    private Map<String, String> getFallBackMasterNode(AbstractProject project) throws EnvInjectException {
+    private Map<String, String> getFallBackMasterNode(Job<?, ?> job) throws EnvInjectException {
         Node masterNode = getMasterNode();
         if (masterNode == null) {
-            return gatherEnvVarsMaster(project);
+            return gatherEnvVarsMaster(job);
         }
-        return getDefaultEnvVarsJob(project, masterNode);
+        return getDefaultEnvVarsJob(job, masterNode);
     }
 
     private Node getMasterNode() {
@@ -97,9 +98,9 @@ public class EnvVarsResolver implements Serializable {
         return computer.getNode();
     }
 
-    public String resolveEnvVars(AbstractBuild build, String value) throws EnvInjectException {
+    public String resolveEnvVars(Run<?, ?> run, String value) throws EnvInjectException {
 
-        if (build == null) {
+        if (run == null) {
             throw new NullPointerException("A build object must be set.");
         }
 
@@ -107,27 +108,27 @@ public class EnvVarsResolver implements Serializable {
             return null;
         }
 
-        return Util.replaceMacro(value, getEnVars(build));
+        return Util.replaceMacro(value, getEnVars(run));
     }
 
 
-    private Map<String, String> getDefaultEnvVarsJob(AbstractProject project, Node node) throws EnvInjectException {
-        assert project != null;
+    private Map<String, String> getDefaultEnvVarsJob(Job<?, ?> job, Node node) throws EnvInjectException {
+        assert job != null;
         assert node != null;
         assert node.getRootPath() != null;
         //--- Same code for master or a slave node
-        Map<String, String> result = gatherEnvVarsMaster(project);
-        result.putAll(gatherEnvVarsNode(project, node));
+        Map<String, String> result = gatherEnvVarsMaster(job);
+        result.putAll(gatherEnvVarsNode(job, node));
         result.putAll(gatherEnvVarsNodeProperties(node));
         return result;
     }
 
-    private Map<String, String> gatherEnvVarsMaster(AbstractProject project) throws EnvInjectException {
-        assert project != null;
+    private Map<String, String> gatherEnvVarsMaster(Job<?, ?> job) throws EnvInjectException {
+        assert job != null;
         EnvVars env = new EnvVars();
         env.put("JENKINS_SERVER_COOKIE", Util.getDigestOf("ServerID:" + Hudson.getInstance().getSecretKey()));
         env.put("HUDSON_SERVER_COOKIE", Util.getDigestOf("ServerID:" + Hudson.getInstance().getSecretKey())); // Legacy compatibility
-        env.put("JOB_NAME", project.getFullName());
+        env.put("JOB_NAME", job.getFullName());
         env.put("JENKINS_HOME", Hudson.getInstance().getRootDir().getPath());
         env.put("HUDSON_HOME", Hudson.getInstance().getRootDir().getPath());   // legacy compatibility
 
@@ -135,7 +136,7 @@ public class EnvVarsResolver implements Serializable {
         if (rootUrl != null) {
             env.put("JENKINS_URL", rootUrl);
             env.put("HUDSON_URL", rootUrl); // Legacy compatibility
-            env.put("JOB_URL", rootUrl + project.getUrl());
+            env.put("JOB_URL", rootUrl + job.getUrl());
         }
 
         return env;
@@ -182,8 +183,8 @@ public class EnvVarsResolver implements Serializable {
         return env;
     }
 
-    private Map<String, String> gatherEnvVarsNode(AbstractProject project, Node node) throws EnvInjectException {
-        assert project != null;
+    private Map<String, String> gatherEnvVarsNode(Job<?, ?> job, Node node) throws EnvInjectException {
+        assert job != null;
         assert node != null;
         assert node.getRootPath() != null;
         try {
@@ -195,9 +196,12 @@ public class EnvVarsResolver implements Serializable {
 
             envVars.put("NODE_NAME", node.getNodeName());
             envVars.put("NODE_LABELS", Util.join(node.getAssignedLabels(), " "));
-            FilePath wFilePath = project.getSomeWorkspace();
-            if (wFilePath != null) {
-                envVars.put("WORKSPACE", wFilePath.getRemote());
+            
+            if (job instanceof AbstractProject) {
+                FilePath wFilePath = ((AbstractProject)job).getSomeWorkspace();
+                if (wFilePath != null) {
+                    envVars.put("WORKSPACE", wFilePath.getRemote());
+                }
             }
 
             return envVars;


### PR DESCRIPTION
This change deprecates obsolete and incompatible methods, which have been replaced in https://github.com/jenkinsci/envinject-api-plugin/pull/1

* [JENKINS-43845](https://issues.jenkins-ci.org/browse/JENKINS-43845) - Decouple EnvInject Lib logic to a plugin
* [JENKINS-43535](https://issues.jenkins-ci.org/browse/JENKINS-43535) - Make API compatible with non-AbstractProject types

@reviewbybees 