### PR TITLE
[JENKINS-44965] - Restrict the direct access to EnvInjectAction#envMap

### DIFF
--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -16,6 +16,8 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.RunAction2;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * @author Gregory Boissinot
@@ -24,6 +26,12 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
 
     public static final String URL_NAME = "injectedEnvVars";
 
+    /**
+     * Local cache of environment variables.
+     * This cache may be null if the loading has never been performed.
+     * Use {@link #getEnvMap()} in external API
+     */
+    @Restricted(NoExternalUse.class)
     protected transient @CheckForNull Map<String, String> envMap;
  
     private transient @Nonnull Run<?, ?> build;


### PR DESCRIPTION
Prevents further occurrences of issues like [JENKINS-44965](https://issues.jenkins-ci.org/browse/JENKINS-44965). See https://github.com/jenkinsci/envinject-plugin/pull/121

@reviewbybees 