### PR TITLE
[JENKINS-46479] Prevent environment variables from being deleted on existing builds

### DIFF
--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -130,11 +130,8 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
         try {
             EnvInjectSavable dao = new EnvInjectSavable();
 
-            Map<String, String> toWrite = getEnvMap();
-            if (toWrite == null) {
-                toWrite = Collections.<String, String>emptyMap();
-            }
-
+            Map<String, String> toWrite = envMap != null ? envMap : Collections.<String, String>emptyMap();
+            
             if (rootDir == null) {
                 dao.saveEnvironment(build.getRootDir(), Maps.transformEntries(toWrite,
                         new Maps.EntryTransformer<String, String, String>() {

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -45,6 +45,9 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
     @Override
     public void onLoad(Run<?, ?> run) {
         build = run;
+        if (envMap == null) {
+            envMap = getEnvMap();
+        }
     }
  
     /**

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.StaplerProxy;
 import java.io.File;
 import java.io.ObjectStreamException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.CheckForNull;
@@ -104,6 +105,10 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
             //file (injectedEnvVars.txt by default).
             try {
                 Map<String, String> result = getEnvironment(build);
+                if (build != null && build.getParent() != null) {
+                    // Cache the result so we don't keep loading the environment from disk.
+                    envMap = result == null ? new HashMap<String, String>(0) : result;
+                }
                 return result == null ? null : UnmodifiableMap.decorate(result);
             } catch (EnvInjectException e) {
                 return null;

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -45,9 +45,6 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
     @Override
     public void onLoad(Run<?, ?> run) {
         build = run;
-        if (envMap == null) {
-            envMap = getEnvMap();
-        }
     }
  
     /**

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -130,8 +130,11 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
         try {
             EnvInjectSavable dao = new EnvInjectSavable();
 
-            Map<String, String> toWrite = envMap != null ? envMap : Collections.<String, String>emptyMap();
-            
+            Map<String, String> toWrite = getEnvMap();
+            if (toWrite == null) {
+                toWrite = Collections.<String, String>emptyMap();
+            }
+
             if (rootDir == null) {
                 dao.saveEnvironment(build.getRootDir(), Maps.transformEntries(toWrite,
                         new Maps.EntryTransformer<String, String, String>() {


### PR DESCRIPTION
[JENKINS-46479](https://issues.jenkins-ci.org/browse/JENKINS-46479)

When deserializing EnvInjectAction objects from injectedEnvVars.txt, [readResolve](https://github.com/dwnusbaum/envinject-lib/blob/dab1c21d1a1b1e35cfdada95ec3ef3be77dc70e2/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java#L187-L212) is called before [onLoad](https://github.com/dwnusbaum/envinject-lib/blob/dab1c21d1a1b1e35cfdada95ec3ef3be77dc70e2/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java#L46-L48), so `readResolve` initializes `envMap` to null because `build` is null (rootDir/resultVariables are always null unless the job used an older version of this library).

Subsequent calls to `getEnvVars` will look up `envMap` using the `build` object, resulting in the correct environment variables, but the `envMap` field will never be updated. Then, when `writeReplace` is called, the empty field is used directly and all existing variables on disk are deleted.

Anything that saves an existing build with a deserialized EnvInjectAction will cause this bug, i.e Restarting Jenkins and then promoting an existing build.

If there is a standard way to serialize/deserialize a reference to the `build` object, that might be preferable to this fix.

@reviewbybees