### PR TITLE
[JENKINS-47167] - Handle null build when serializing the object to the disk, patch FindBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
           <artifactId>findbugs-maven-plugin</artifactId>
           <configuration>
             <effort>Max</effort>
+            <threshold>Low</threshold>
             <failOnError>true</failOnError>
           </configuration>
           <executions>

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectLogger.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectLogger.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.lib.envinject;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.TaskListener;
 
 import java.io.Serializable;
@@ -8,6 +9,7 @@ import javax.annotation.Nonnull;
 /**
  * @author Gregory Boissinot
  */
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Legacy code")
 public class EnvInjectLogger implements Serializable {
 
     @Nonnull

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectSavable.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvInjectSavable.java
@@ -11,6 +11,8 @@ import java.util.TreeMap;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import javax.annotation.Nonnull;
+
 /**
  * @author Gregory Boissinot
  * @deprecated The actual version of this API class is located in EnvInject API Plugin
@@ -53,7 +55,7 @@ public class EnvInjectSavable {
     }
 
     @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "Deprecated class")
-    public void saveEnvironment(File rootDir, Map<String, String> envMap) throws EnvInjectException {
+    public void saveEnvironment(@Nonnull File rootDir,@Nonnull Map<String, String> envMap) throws EnvInjectException {
         FileWriter fileWriter = null;
         try {
             File f = new File(rootDir, ENVINJECT_TXT_FILENAME);

--- a/src/main/java/org/jenkinsci/lib/envinject/service/EnvVarsResolver.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/service/EnvVarsResolver.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.lib.envinject.service;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Util;
@@ -29,6 +30,7 @@ import javax.annotation.Nonnull;
  */
 @Deprecated
 @Restricted(NoExternalUse.class)
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Deprecated code")
 public class EnvVarsResolver implements Serializable {
 
     public Map<String, String> getPollingEnvVars(AbstractProject project, /*can be null*/ Node node) throws EnvInjectException {
@@ -204,11 +206,7 @@ public class EnvVarsResolver implements Serializable {
         }
 
         try {
-            Map<String, String> envVars = new EnvVars(p.act(new MasterToSlaveCallable<Map<String, String>, EnvInjectException>() {
-                public Map<String, String> call() throws EnvInjectException {
-                    return EnvVars.masterEnvVars;
-                }
-            }));
+            Map<String, String> envVars = new EnvVars(p.act(new SystemEnvVarsGetter()));
 
             envVars.put("NODE_NAME", node.getNodeName());
             envVars.put("NODE_LABELS", Util.join(node.getAssignedLabels(), " "));
@@ -223,6 +221,12 @@ public class EnvVarsResolver implements Serializable {
             throw new EnvInjectException(ioe);
         } catch (InterruptedException ie) {
             throw new EnvInjectException(ie);
+        }
+    }
+
+    private static final class SystemEnvVarsGetter extends MasterToSlaveCallable<Map<String, String>, EnvInjectException> {
+        public Map<String, String> call() throws EnvInjectException {
+            return EnvVars.masterEnvVars;
         }
     }
 


### PR DESCRIPTION
FindBugs was using the default “Medium” threshold, and hence it was missing some NPE risks.
The change improves diagnostics for JENKINS-47167 and cleanups some other code bits

https://issues.jenkins-ci.org/browse/JENKINS-47167

@reviewbybees