### PR TITLE
[JENKINS-47574] - Prevent NPE in EnvInjectAction#getEnvironment() when it's called in readResolve()

### DIFF
--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -162,7 +162,7 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
             justification = "JENKINS-47574 - parent may be null during readResolve()")
     private static boolean runHasNoParent(@Nonnull Run<?,?> run) {
-        return run.getParent() != null;
+        return run.getParent() == null;
     }
 
     @CheckForNull

--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -159,10 +159,21 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
         return this;
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+            justification = "JENKINS-47574 - parent may be null during readResolve()")
+    private static boolean runHasNoParent(@Nonnull Run<?,?> run) {
+        return run.getParent() != null;
+    }
+
     @CheckForNull
     private Map<String, String> getEnvironment(@CheckForNull Run<?, ?> build) throws EnvInjectException {
 
         if (build == null) {
+            return null;
+        }
+
+        // It happens in the case of usage of this logic for a not-fully loaded build
+        if (runHasNoParent(build)) {
             return null;
         }
 


### PR DESCRIPTION
subj. Happens only in corner-cases from what I see.
Tests to be delivered later

https://issues.jenkins-ci.org/browse/JENKINS-47574

@reviewbybees

