### PR TITLE
[JENKINS-64398] Fix accessibility of `writeReplace` method

### DIFF
--- a/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
+++ b/src/main/java/org/jenkinsci/lib/envinject/EnvInjectAction.java
@@ -131,7 +131,7 @@ public class EnvInjectAction implements RunAction2, StaplerProxy {
     }
 
     @SuppressWarnings("unused")
-    private Object writeReplace() throws ObjectStreamException {
+    protected Object writeReplace() throws ObjectStreamException {
         try {
             EnvInjectSavable dao = new EnvInjectSavable();
 


### PR DESCRIPTION
Fixing https://issues.jenkins.io/browse/JENKINS-64398 as per https://github.com/jenkinsci/jep/blob/master/jep/228/README.adoc#inherited-private-serialization-methods

```bash
mvn -f envinject-plugin test -Djenkins.version=2.266 -Dtest=EnvInjectVarListTest\#envVarsShouldBeCachedProperlyAfterReload
```

fails unless this PR is added as a snapshot dep.
